### PR TITLE
jx-quickstart-gke to 0.0.8

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -12,4 +12,4 @@ dependencies:
   version: 2.3.89
 - name: jx-quickstart-gke
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.7
+  version: 0.0.8


### PR DESCRIPTION
Promote jx-quickstart-gke to version 0.0.8